### PR TITLE
Replace OSDDownloadDownloadPackages with logic to copy files

### DIFF
--- a/ConfigMgr/OS Deployment/Invoke-CMDownloadBiosPackage.ps1
+++ b/ConfigMgr/OS Deployment/Invoke-CMDownloadBiosPackage.ps1
@@ -163,7 +163,10 @@ Process {
 
                         # Attempt to set task sequence variable
                         try {
-                            $TSEnvironment.Value("OSDDownloadDownloadPackages") = $($PackageList[0].PackageID)
+                            $BiosPackageID = $($Package[0].PackageID)
+                            $TSBiosPath = "$($TSEnvironment.Value('_SMSTSMDataPath'))\BIOS"
+                            Start-Process "smsswd.exe" -ArgumentList "/run:$BiosPackageID","robocopy",".\",$TSBiosPath,"/E"
+                            if (Test-Path $TSBiosPath) { $TSEnvironment.Value('OSDBiosPath') = $TSBiosPath }
                             Write-CMLogEntry -Value "Successfully set OSDDownloadDownloadPackages variable with PackageID: $($PackageList[0].PackageID)" -Severity 1
                         }
                         catch [System.Exception] {
@@ -176,7 +179,10 @@ Process {
                         # Attempt to set task sequence variable
                         try {
                             $Package = $PackageList | Where-Object {$_.PackageName -match $OSImageVersion} | Sort-Object -Property PackageCreated -Descending | Select-Object -First 1
-                            $TSEnvironment.Value("OSDDownloadDownloadPackages") = $($Package[0].PackageID)
+                            $BiosPackageID = $($Package[0].PackageID)
+                            $TSBiosPath = "$($TSEnvironment.Value('_SMSTSMDataPath'))\BIOS"
+                            Start-Process "smsswd.exe" -ArgumentList "/run:$BiosPackageID","robocopy",".\",$TSBiosPath,"/E"
+                            if (Test-Path $TSBiosPath) { $TSEnvironment.Value('OSDBiosPath') = $TSBiosPath }
                             Write-CMLogEntry -Value "Successfully set OSDDownloadDownloadPackages variable with PackageID: $($Package[0].PackageID)" -Severity 1
                         }
                         catch [System.Exception] {


### PR DESCRIPTION
For “Download Package Content” option to work, the deployment of the task sequence has to be configured to “Download content locally…” instead of “Access content directly..”. 

https://blogs.technet.microsoft.com/system_center_configuration_manager_operating_system_deployment_support_blog/2016/12/28/apply-driver-package-task-fails-when-the-adk-is-upgrade-to-adk-10-1607/#comment-4155 

Because of this, I had to modify the script to actually download the files itself, eliminating the “Download Package Content” . Obviously, the logging needs to be updated to reflect this, but this file change submission just includes the bare minimum to add the functionality.