### PR TITLE
Added Validation to the Language Parameter

### DIFF
--- a/ConfigMgr/Site Administration/Set-CMAdditionalUpdateLanguagesForOffice365.ps1
+++ b/ConfigMgr/Site Administration/Set-CMAdditionalUpdateLanguagesForOffice365.ps1
@@ -39,6 +39,10 @@ param(
     [parameter(Mandatory=$true, HelpMessage="Specify the additional languages as a string array. Pass an empty string to clear the existing additional languages.")]
     [ValidateNotNull()]
     [AllowEmptyString()]
+    [ValidateSet("","en-us","ar-sa","bg-bg","zh-cn","zh-tw","hr-hr","cs-cz","da-dk","nl-nl","et-ee",
+    "fi-fi","fr-fr","de-de","el-gr","he-il","hi-in","hu-hu","id-id","it-it","ja-jp",
+    "kk-kz","ko-kr","lv-lv","lt-lt","ms-my","nb-no","pl-pl","pt-br","pt-pt","ro-ro",
+    "ru-ru","sr-latn-rs","sk-sk","sl-si","es-es","sv-se","th-th","tr-tr","uk-ua","vi-vn")]
     [string[]]$Language
 )
 Begin {


### PR DESCRIPTION
allow none or only the supported O365 Languages. It also gives hints on the commandline for the users on what languages are available