### PR TITLE
Fix $os image version

### DIFF
--- a/ConfigMgr/OS Deployment/Invoke-CMDownloadDriverPackage.ps1
+++ b/ConfigMgr/OS Deployment/Invoke-CMDownloadDriverPackage.ps1
@@ -164,7 +164,8 @@ Process {
     # Determine OS Image version for running task sequence from web service
     try {
         $TSPackageID = $TSEnvironment.Value("_SMSTSPackageID")
-        $OSImageVersion = $WebService.GetCMOSImageVersionForTaskSequence($SecretKey, $TSPackageID)
+        $versionAry = ($WebService.GetCMOSImageVersionForTaskSequence($SecretKey, $TSPackageID)).split('.')
+        $OSImageVersion = $versionAry[0] + '.' + $versionAry[1] + '.' + $versionAry[2] + '.0'
         Write-CMLogEntry -Value "Retrieved OS Image version from web service: $($OSImageVersion)" -Severity 1
     }
     catch [System.Exception] {

--- a/ConfigMgr/OS Deployment/Invoke-CMDownloadDriverPackage.ps1
+++ b/ConfigMgr/OS Deployment/Invoke-CMDownloadDriverPackage.ps1
@@ -164,8 +164,8 @@ Process {
     # Determine OS Image version for running task sequence from web service
     try {
         $TSPackageID = $TSEnvironment.Value("_SMSTSPackageID")
-        $versionAry = ($WebService.GetCMOSImageVersionForTaskSequence($SecretKey, $TSPackageID)).split('.')
-        $OSImageVersion = $versionAry[0] + '.' + $versionAry[1] + '.' + $versionAry[2] + '.0'
+        $OSAry = ($WebService.GetCMOSImageVersionForTaskSequence($SecretKey, $TSPackageID)).split('.')
+        $OSImageVersion = "$($OSAry[0]).$($OSAry[1]).$($OSAry[2]).0"
         Write-CMLogEntry -Value "Retrieved OS Image version from web service: $($OSImageVersion)" -Severity 1
     }
     catch [System.Exception] {

--- a/ConfigMgr/OS Deployment/Invoke-CMDownloadDriverPackage.ps1
+++ b/ConfigMgr/OS Deployment/Invoke-CMDownloadDriverPackage.ps1
@@ -164,7 +164,7 @@ Process {
     # Determine OS Image version for running task sequence from web service
     try {
         $TSPackageID = $TSEnvironment.Value("_SMSTSPackageID")
-        $OSAry = ($WebService.GetCMOSImageVersionForTaskSequence($SecretKey, $TSPackageID)).split('.')
+        $OSAry = "$($WebService.GetCMOSImageVersionForTaskSequence($SecretKey, $TSPackageID))".split('.')
         $OSImageVersion = "$($OSAry[0]).$($OSAry[1]).$($OSAry[2]).0"
         Write-CMLogEntry -Value "Retrieved OS Image version from web service: $($OSImageVersion)" -Severity 1
     }


### PR DESCRIPTION
In _Invoke-CMDownloadDriverPackage.ps1_  when queryingOSImageVersion can sometimes return a build
version with a revision such as "10.0.15063.**296**" when comparing with the  package in SCCM 
it will not match "10.0.15063.0" and therefore not find the package.