### PR TITLE
Remove -notin for PS2.0 compat

### DIFF
--- a/ConfigMgr/OS Deployment/Invoke-CMDownloadDriverPackage.ps1
+++ b/ConfigMgr/OS Deployment/Invoke-CMDownloadDriverPackage.ps1
@@ -189,7 +189,7 @@ Process {
     if ($OSName -ne $null) {
         # Validate not virtual machine
         $ComputerSystemType = Get-WmiObject -Class Win32_ComputerSystem | Select-Object -ExpandProperty "Model"
-        if ($ComputerSystemType -notin @("Virtual Machine", "VMware Virtual Platform", "VirtualBox", "HVM domU", "KVM")) {
+        if (@("Virtual Machine", "VMware Virtual Platform", "VirtualBox", "HVM domU", "KVM") -notcontains $ComputerSystemType ) {
             # Process packages returned from web service
             if ($Packages -ne $null) {
                 # Add packages with matching criteria to list


### PR DESCRIPTION
Use `-notcontains` instead of `-notin `for backwards compatibility with PS 2.0. Powershell 2.0 may still be prevalent in Windows 7 environments and factors into in-place upgrades.